### PR TITLE
Do not hard bind refuse 0.0.4 , make it minimal required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
 	python_requires = '>=3.{MINOR:d}'.format(MINOR = python_minor_min),
 	install_requires = [
 		'click>=7.0',
-		'refuse==0.0.4',
+		'refuse>=0.0.4',
 		'xmltodict'
 		],
 	extras_require = {'dev': development_deps_list},


### PR DESCRIPTION
Exact version specifications, if really needed, IMHO better go to requirements.txt . Have a look e.g. at an old https://caremad.io/posts/2013/07/setup-vs-requirement/ about setup.py vs requirements.txt principled differences.

Having it relaxed, may be we could use this package setup as a regression test for refuse.